### PR TITLE
[feat] #7 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
@@ -1,0 +1,17 @@
+package com.leets.X.domain.user.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+
+    SUCCESS_SAVE(201,"회원가입에 성공했습니다.");
+
+    private final int code;
+    private final String message;
+
+}
+

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -1,9 +1,34 @@
 package com.leets.X.domain.user.controller;
 
+import com.leets.X.domain.user.exception.UserNotFoundException;
+import com.leets.X.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import static com.leets.X.domain.user.controller.ResponseMessage.SUCCESS_SAVE;
+
+// 스웨거에서 controller 단위 설명 추가
+@Tag(name = "USER")
+@RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
+
+    @GetMapping("/")
+    @Operation(summary = "테스트용 API")// 스웨거에서 API 별로 설명을 넣기 위해 사용하는 어노테이션
+    public String index() {
+        throw new UserNotFoundException();
+    }
+
+    // API 응답 예시를 위한 테스트 API
+    @GetMapping("/test")
+    @Operation(summary = "테스트용 API2")
+    public ResponseDto<Void> test() {
+        return ResponseDto.response(SUCCESS_SAVE.getCode(), SUCCESS_SAVE.getMessage());
+    }
+
 }

--- a/src/main/java/com/leets/X/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/com/leets/X/domain/user/exception/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.leets.X.domain.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    USER_NOT_FOUND(404,"존재하지 않는 유저입니다.");
+
+    private final int code;
+    private final String message;
+
+}

--- a/src/main/java/com/leets/X/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/leets/X/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package com.leets.X.domain.user.exception;
+
+import com.leets.X.global.exception.BaseException;
+
+import static com.leets.X.domain.user.exception.ErrorMessage.*;
+
+// 모든 사용자 정의 예외는 BaseException을 상속할 것
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(USER_NOT_FOUND.getCode(), USER_NOT_FOUND.getMessage());
+    }
+
+}

--- a/src/main/java/com/leets/X/global/common/response/ResponseDto.java
+++ b/src/main/java/com/leets/X/global/common/response/ResponseDto.java
@@ -1,0 +1,31 @@
+package com.leets.X.global.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseDto<T> {
+
+    private int code;
+    private String message;
+    private T data;
+
+    // 실패시 호출(데이터가 비어있음)
+    public static <T> ResponseDto<T> errorResponse(int code, String message) {
+        return new ResponseDto<>(code, message, null);
+    }
+
+    // data가 없는 응답시 호출(성공)
+    public static <T> ResponseDto<T> response(int code, String message) {
+        return new ResponseDto<>(code, message, null);
+    }
+
+    // 성공시 호출(데이터 포함)
+    public static <T> ResponseDto<T> response(int code, String message, T data) {
+        return new ResponseDto<>(code, message, data);
+    }
+
+}

--- a/src/main/java/com/leets/X/global/exception/BaseException.java
+++ b/src/main/java/com/leets/X/global/exception/BaseException.java
@@ -1,0 +1,15 @@
+package com.leets.X.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final int errorCode;
+
+    public BaseException(int errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/leets/X/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/X/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package com.leets.X.global.exception;
+
+import com.leets.X.global.common.response.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
+
+    // 사용자 정의 예외 발생 시
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ResponseDto<Void>> handle(BaseException e) {
+
+        // 개발 용이성을 위해 전체 에러로그를 재출력. 운영 환경에서는 제거할 것  
+        log.warn(e.getMessage(), e);
+        // 간략한 예외 정보 출력  
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), e.getErrorCode(), e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(e.getErrorCode(), e.getMessage());
+
+        return ResponseEntity
+                .status(e.getErrorCode()) // 실제 HTTP 상태 코드 설정  
+                .body(response); // 본문에 ResponseDto 전달  
+    }
+
+    // 파라미터가 없을 시
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ResponseDto<Void>> handle(MissingServletRequestParameterException e) {
+        int statusCode = 400;
+
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(statusCode, e.getMessage());
+
+        return ResponseEntity
+                .status(statusCode)
+                .body(response);
+    }
+
+    // @Valid에서 발생한 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Void>> handle(MethodArgumentNotValidException e) {
+        int statusCode = 400;
+
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(statusCode, e.getMessage());
+
+        return ResponseEntity
+                .status(statusCode)
+                .body(response);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResponseDto<Void>> handle(IllegalArgumentException e) {
+        int statusCode = 400;
+
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(statusCode, e.getMessage());
+
+        return ResponseEntity
+                .status(statusCode) // 실제 HTTP 상태 코드 설정
+                .body(response);
+    }
+
+    // 잡지 못한 이외의 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handle(Exception e) {
+        int statusCode = 500;
+
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(statusCode, e.getMessage());
+
+        return ResponseEntity
+                .status(statusCode) // 실제 HTTP 상태 코드 설정
+                .body(response);
+    }
+
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 글로벌 예외 핸들러를 추가하였습니다
- 글로벌 예외 추가와 이를 위한 커스텀 응답 객체 및 커스텀 예외를 구현했습니다

## 2. 어떤 위험이나 장애를 발견했나요?
### GlobalExceptionHandler 관련
- 예외처리의 경우 모든 예외를 GlobalExceptionHandler가 잡아서 처리하게됩니다. 따라서 거의 모든 예외는 try-catch 문으로 처리하지 않고, 단순히 예외를 던지는 것으로 구현하시면 됩니다.
- 이가 가능한 원리는 어플리케이션 단에서 발생하는 예외를 @ExceptionHandler 어노테이션이 붙은 핸들러가 잡아서 처리하기 때문입니다
- 해당 어노테이션을 이용한 handler 구현 시 잡아주는 예외의 class를 명시해주면 해당 클래스의 예외가 발생시 해당 handler가 잡아서 처리하게 됩니다. catch의 역할을 여기서 한다고 생각해주시면 됩니다.
- 해당 핸들러 구현 방식이 크게 두 가지가 있는 것 같습니다. Http header의 status를 예외 코드와 동일하게 맞춰서 보내준다 / status는 200으로 반환하되, api body(본문)에 code를 예외코드로 변경해서 보내준다. 
- 이는 프론트와 상의를 통해서 예외 코드에 맞게 status를 반환하는 쪽으로 구현했습니다. 해당 구현을 위해 에러 핸들러는 ResponseEntity를 사용해야해서 해당 방식으로 구현하였습니다.
- 요청 성공시에는 status는 200으로 고정하여 반환하고, 내부 code를 세부적으로 맞춰서 보내주기로 하였습니다.
- 참조했던 블로그 남기겠습니다.
> https://adjh54.tistory.com/79

### 커스텀 응답 객체
- 기존 controller 단에서 dto를 객체에 담아 응답하기 위해 ResponseEntity<>를 사용했습니다. 하지만 응답의 형태를 고정되게 클라이언트에게 전달하기 위해 커스텀 응답 객체를 구현했습니다.
- 객체는 ResponseDto로 정하였고, 에러 발생 / data(body)가 없는 응답 / data가 있는 응답. 3가지로 나눠 구현했습니다.
- 해당 객체 사용 방법은 UserController에 간단한 방법으로 정리는 해뒀으니 참고 바랍니다. 
- controller 단에서는 ResponseDto.response(ResponseMessage.코드, ResponseMessage.메시지)로 상수로 넣어주게 됩니다. 컨트롤러, 서비스 단에서 문자열을 직접적으로 사용하는 것은 지양하기 때문에 상수로 관리하고자 하였습니다.
- 관심사 분리를 위해 Error에 관련된 상수는 각 도메인 하위 exception 아래에 구현했고, 성공 메시지는 controller에만 사용되기 때문에 이곳에 구현해뒀습니다. 하나로 통합하는 방식도 있기 때문에 팀원 분들의 의견도 들어보고 싶습니다.
- 자세한 사항은 아래 블로그 참고 바랍니다
> https://velog.io/@win-luck/Springboot-스프링-API-구현-커스텀-응답객체-REST-API-HttpsCode-GlobalExceptionHandler

### 예외 관련
- 서비스에서 커스텀 예외를 구현할 때 상속을 하는 BaseException을 만들어뒀습니다. 그 이유는 해당 예외를 상속하는 예외들은 개발자들이 커스텀한 예외임을 명시할 수 있고, GlobalExceptionHandler에서 처리하기 용이하기 때문입니다.
- 해당 예외를 상속하는 도메인 별 예외는 도메인 하위 exception 디렉토리에 구현 바라며, code와 message는 ErrorMessage enum 클래스에 추가하여 상수로 관리해주시기 바랍니다.
- http 예외 상태 코드 참고 바랍니다.

## 3. 관련 스크린샷을 첨부해주세요.
### 응답 객체 형태
에러 발생시
<img width="808" alt="image" src="https://github.com/user-attachments/assets/e46a75a3-9ad4-4673-a7c2-890f23ebc345">

요청 반환 성공 시
<img width="816" alt="image" src="https://github.com/user-attachments/assets/4baba885-85c1-4065-88df-9185738d1db0">

<br>

## 4. 완료 사항
구현 및 테스트 완료

## 5. 추가 사항
- 오류있는 코드가 있을 수 있으니 꼼꼼한 리뷰 부탁 드립니다.
- 제가 알고 있는 내용을 최대한 알려드리고싶어 PR을 최대한 자세하게 작성하였습니다. 해당 방식이 나으신지, 아니면 스스로 찾아보면서 공부하는 방식이 나으신지 알려주셨으면 합니다! 감사합니다!
