### PR TITLE
[feat] #11스프링시큐리티 예외처리 및 JWT 로직 일부 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// Oauth2
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leets/X/XApplication.java
+++ b/src/main/java/com/leets/X/XApplication.java
@@ -2,8 +2,10 @@ package com.leets.X;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class XApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
 
     USER_SAVE_SUCCESS(201,"회원가입에 성공했습니다."),
-    LOGIN_SUCCESS(200,"로그인에 성공했습니다.");
+    LOGIN_SUCCESS(200,"로그인에 성공했습니다."),
+    INIT_PROFILE_SUCCESS(200, "프로필 초기설정에 성공했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ResponseMessage {
 
 
-    SUCCESS_SAVE(201,"회원가입에 성공했습니다.");
+    USER_SAVE_SUCCESS(201,"회원가입에 성공했습니다."),
+    LOGIN_SUCCESS(200,"로그인에 성공했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.leets.X.domain.user.controller;
 
-import com.leets.X.domain.user.domain.enums.LoginStatus;
+import com.leets.X.domain.user.service.LoginStatus;
 import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
-import com.leets.X.domain.user.servie.UserService;
+import com.leets.X.domain.user.service.UserService;
 import com.leets.X.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -1,21 +1,20 @@
 package com.leets.X.domain.user.controller;
 
-import com.leets.X.domain.user.service.LoginStatus;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
+import com.leets.X.domain.user.service.LoginStatus;
 import com.leets.X.domain.user.service.UserService;
 import com.leets.X.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-import static com.leets.X.domain.user.controller.ResponseMessage.LOGIN_SUCCESS;
-import static com.leets.X.domain.user.controller.ResponseMessage.USER_SAVE_SUCCESS;
+import static com.leets.X.domain.user.controller.ResponseMessage.*;
 
 // 스웨거에서 controller 단위 설명 추가
 @Tag(name = "USER")
@@ -34,6 +33,18 @@ public class UserController {
             return ResponseDto.response(LOGIN_SUCCESS.getCode(), LOGIN_SUCCESS.getMessage(), response);
         }
         return ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage(), response);
+    }
+
+    /*
+        * JWT 인증시 Authentication 객체를 만들 때 user의 email만 넣어서 만들었기 떄문에 @AuthenticationPrincipal로 인증 정보를 가져오면 email이 반환됨
+        * 우리의 경우 소셜 로그인만 진행하기 때문에 이메일 중복이 없어 해당 방식도 문제 없지만, 토큰의 subject로 user_id와 email을 넣는게 나을 것 같음
+        * 또한 인증된 사용자 정보를 객체, email로 가져오는 것보다 id로 가져오는 것이 인덱싱 방면에서 성능이 더 좋을 듯
+     */
+    @PatchMapping("/init")
+    @Operation(summary = "최초 로그인시 정보 입력")
+    public ResponseDto<String> initUserProfile(@RequestBody @Valid UserInitializeRequest request, @AuthenticationPrincipal @Parameter(hidden = true) String email) {// 스웨거에서 해당 정보 입력을 받지 않기 위해 hidden으로 설정
+        userService.initProfile(request, email);
+        return ResponseDto.response(INIT_PROFILE_SUCCESS.getCode(), INIT_PROFILE_SUCCESS.getMessage());
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -1,15 +1,21 @@
 package com.leets.X.domain.user.controller;
 
-import com.leets.X.domain.user.exception.UserNotFoundException;
+import com.leets.X.domain.user.domain.enums.LoginStatus;
+import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
+import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
+import com.leets.X.domain.user.servie.UserService;
 import com.leets.X.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.leets.X.domain.user.controller.ResponseMessage.SUCCESS_SAVE;
+import static com.leets.X.domain.user.controller.ResponseMessage.LOGIN_SUCCESS;
+import static com.leets.X.domain.user.controller.ResponseMessage.USER_SAVE_SUCCESS;
 
 // 스웨거에서 controller 단위 설명 추가
 @Tag(name = "USER")
@@ -18,17 +24,16 @@ import static com.leets.X.domain.user.controller.ResponseMessage.SUCCESS_SAVE;
 @RequestMapping("/api/v1/users")
 public class UserController {
 
-    @GetMapping("/")
-    @Operation(summary = "테스트용 API")// 스웨거에서 API 별로 설명을 넣기 위해 사용하는 어노테이션
-    public String index() {
-        throw new UserNotFoundException();
-    }
+    private final UserService userService;
 
-    // API 응답 예시를 위한 테스트 API
-    @GetMapping("/test")
-    @Operation(summary = "테스트용 API2")
-    public ResponseDto<Void> test() {
-        return ResponseDto.response(SUCCESS_SAVE.getCode(), SUCCESS_SAVE.getMessage());
+    @PostMapping("/login")
+    @Operation(summary = "구글 소셜 회원가입 및 로그인")
+    public ResponseDto<UserSocialLoginResponse> socialLogin(@RequestBody @Valid UserSocialLoginRequest request) {
+        UserSocialLoginResponse response = userService.authenticate(request.authCode());
+        if(response.status() == LoginStatus.LOGIN){
+            return ResponseDto.response(LOGIN_SUCCESS.getCode(), LOGIN_SUCCESS.getMessage(), response);
+        }
+        return ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage(), response);
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -1,11 +1,12 @@
 package com.leets.X.domain.user.domain;
 
 import com.leets.X.domain.user.domain.enums.Gender;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 // mysql에서 user 테이블이 존재 하기 때문에 다른 이름으로 지정
@@ -33,7 +34,7 @@ public class User extends BaseTimeEntity {
 
     private String phoneNum;
 
-    private LocalDateTime birth;
+    private LocalDate birth;
 
     private String location;
 
@@ -44,5 +45,10 @@ public class User extends BaseTimeEntity {
     private String introduce;
 
 //    private Image image;
+
+    public void initProfile(UserInitializeRequest dto){
+        this.birth = dto.birth();
+        this.customId = dto.customId();
+    }
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -3,10 +3,7 @@ package com.leets.X.domain.user.domain;
 import com.leets.X.domain.user.domain.enums.Gender;
 import com.leets.X.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Getter
 public class User extends BaseTimeEntity {
 
     @Id
@@ -23,7 +21,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long id;
 
-    private String password;
+    //private String password; // 소셜로그인 구현에는 필요 x
 
     private String customId;
 

--- a/src/main/java/com/leets/X/domain/user/domain/enums/LoginStatus.java
+++ b/src/main/java/com/leets/X/domain/user/domain/enums/LoginStatus.java
@@ -1,0 +1,5 @@
+package com.leets.X.domain.user.domain.enums;
+
+public enum LoginStatus {
+    LOGIN, REGISTER
+}

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserInitializeRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserInitializeRequest.java
@@ -1,0 +1,13 @@
+package com.leets.X.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record UserInitializeRequest(
+        // 이 둘은 필수 입력이기 떄문에 NotBlank 제약
+        @NotNull LocalDate birth, // 날짜의 경우 @NotNull이 적용 x
+        @NotBlank String customId
+) {
+}

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserSaveRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserSaveRequest.java
@@ -1,4 +1,0 @@
-package com.leets.X.domain.user.dto.request;
-
-public record UserSaveRequest() {
-}

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserSocialLoginRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserSocialLoginRequest.java
@@ -1,0 +1,8 @@
+package com.leets.X.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserSocialLoginRequest(
+        @NotBlank String requestCode
+) {
+}

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserSocialLoginRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserSocialLoginRequest.java
@@ -3,6 +3,6 @@ package com.leets.X.domain.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserSocialLoginRequest(
-        @NotBlank String requestCode
+        @NotBlank String authCode
 ) {
 }

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserResponse.java
@@ -1,4 +1,0 @@
-package com.leets.X.domain.user.dto.response;
-
-public record UserResponse() {
-}

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
@@ -1,6 +1,6 @@
 package com.leets.X.domain.user.dto.response;
 
-import com.leets.X.domain.user.domain.enums.LoginStatus;
+import com.leets.X.domain.user.service.LoginStatus;
 import com.leets.X.global.auth.jwt.JwtResponse;
 import lombok.Builder;
 

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
@@ -1,0 +1,13 @@
+package com.leets.X.domain.user.dto.response;
+
+import com.leets.X.domain.user.domain.enums.LoginStatus;
+import com.leets.X.global.auth.jwt.JwtResponse;
+import lombok.Builder;
+
+@Builder
+public record UserSocialLoginResponse(
+        Long id,
+        LoginStatus status,
+        JwtResponse jwtToken
+) {
+}

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
@@ -1,7 +1,7 @@
 package com.leets.X.domain.user.dto.response;
 
 import com.leets.X.domain.user.service.LoginStatus;
-import com.leets.X.global.auth.jwt.JwtResponse;
+import com.leets.X.global.auth.jwt.dto.JwtResponse;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/leets/X/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/leets/X/domain/user/exception/UserNotFoundException.java
@@ -1,6 +1,6 @@
 package com.leets.X.domain.user.exception;
 
-import com.leets.X.global.exception.BaseException;
+import com.leets.X.global.common.exception.BaseException;
 
 import static com.leets.X.domain.user.exception.ErrorMessage.*;
 

--- a/src/main/java/com/leets/X/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/leets/X/domain/user/repository/UserRepository.java
@@ -3,5 +3,11 @@ package com.leets.X.domain.user.repository;
 import com.leets.X.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/com/leets/X/domain/user/service/LoginStatus.java
+++ b/src/main/java/com/leets/X/domain/user/service/LoginStatus.java
@@ -1,4 +1,4 @@
-package com.leets.X.domain.user.domain.enums;
+package com.leets.X.domain.user.service;
 
 public enum LoginStatus {
     LOGIN, REGISTER

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.leets.X.domain.user.service;
 
 import com.leets.X.domain.user.domain.User;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
 import com.leets.X.domain.user.exception.UserNotFoundException;
 import com.leets.X.domain.user.repository.UserRepository;
@@ -26,6 +27,9 @@ public class UserService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
+    /*
+        * 소셜 로그인
+     */
     @Transactional
     public UserSocialLoginResponse authenticate(String authCode) {
         GoogleTokenResponse token = authService.getGoogleAccessToken(authCode);
@@ -39,9 +43,18 @@ public class UserService {
         return registerUser(userInfo);
     }
 
+    /*
+        * 회원가입 시 초기 정보 입력
+     */
+    @Transactional
+    public void initProfile(UserInitializeRequest dto, String email){
+        User user = find(email);
+
+        user.initProfile(dto);
+    }
+
     private UserSocialLoginResponse loginUser(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(UserNotFoundException::new);
+        User user = find(email);
 
         return new UserSocialLoginResponse(user.getId(), LOGIN, generateToken(email));
     }
@@ -62,6 +75,15 @@ public class UserService {
                 .accessToken(jwtProvider.generateAccessToken(email))
                 .refreshToken(jwtProvider.generateRefreshToken())
                 .build();
+    }
+
+    /*
+        * userRepository에서 사용자를 검색하는 메서드
+        * 공통으로 사용되는 부분이 많기 때문에 별도로 분리
+     */
+    private User find(String email){
+        return userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -35,8 +35,10 @@ public class UserService {
         GoogleTokenResponse token = authService.getGoogleAccessToken(authCode);
         GoogleUserInfoResponse userInfo = authService.getGoogleUserInfo(token.access_token());
 
+        String email = userInfo.email();
+
         // 가입된 유저라면 로그인
-        if (userRepository.existsByEmail(userInfo.email())){
+        if (existUser(email)){
             return loginUser(userInfo.email());
         }
         // 아니라면 회원가입
@@ -81,9 +83,13 @@ public class UserService {
         * userRepository에서 사용자를 검색하는 메서드
         * 공통으로 사용되는 부분이 많기 때문에 별도로 분리
      */
-    private User find(String email){
+    public User find(String email){
         return userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    public boolean existUser(String email){
+        return userRepository.existsByEmail(email);
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -8,7 +8,7 @@ import com.leets.X.global.auth.google.AuthService;
 import com.leets.X.global.auth.google.dto.GoogleTokenResponse;
 import com.leets.X.global.auth.google.dto.GoogleUserInfoResponse;
 import com.leets.X.global.auth.jwt.JwtProvider;
-import com.leets.X.global.auth.jwt.JwtResponse;
+import com.leets.X.global.auth.jwt.dto.JwtResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -1,4 +1,4 @@
-package com.leets.X.domain.user.servie;
+package com.leets.X.domain.user.service;
 
 import com.leets.X.domain.user.domain.User;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
@@ -14,8 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.leets.X.domain.user.domain.enums.LoginStatus.LOGIN;
-import static com.leets.X.domain.user.domain.enums.LoginStatus.REGISTER;
+import static com.leets.X.domain.user.service.LoginStatus.LOGIN;
+import static com.leets.X.domain.user.service.LoginStatus.REGISTER;
 
 @Slf4j
 @Service

--- a/src/main/java/com/leets/X/domain/user/servie/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/servie/UserService.java
@@ -1,12 +1,67 @@
 package com.leets.X.domain.user.servie;
 
+import com.leets.X.domain.user.domain.User;
+import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
+import com.leets.X.domain.user.exception.UserNotFoundException;
+import com.leets.X.domain.user.repository.UserRepository;
+import com.leets.X.global.auth.google.AuthService;
+import com.leets.X.global.auth.google.dto.GoogleTokenResponse;
+import com.leets.X.global.auth.google.dto.GoogleUserInfoResponse;
+import com.leets.X.global.auth.jwt.JwtProvider;
+import com.leets.X.global.auth.jwt.JwtResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import static com.leets.X.domain.user.domain.enums.LoginStatus.LOGIN;
+import static com.leets.X.domain.user.domain.enums.LoginStatus.REGISTER;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class UserService {
+
+    private final AuthService authService;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserSocialLoginResponse authenticate(String authCode) {
+        GoogleTokenResponse token = authService.getGoogleAccessToken(authCode);
+        GoogleUserInfoResponse userInfo = authService.getGoogleUserInfo(token.access_token());
+
+        // 가입된 유저라면 로그인
+        if (userRepository.existsByEmail(userInfo.email())){
+            return loginUser(userInfo.email());
+        }
+        // 아니라면 회원가입
+        return registerUser(userInfo);
+    }
+
+    private UserSocialLoginResponse loginUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        return new UserSocialLoginResponse(user.getId(), LOGIN, generateToken(email));
+    }
+
+    private UserSocialLoginResponse registerUser(GoogleUserInfoResponse userInfo) {
+        User user = User.builder()
+                .name(userInfo.name())
+                .email(userInfo.email())
+                .build();
+
+        userRepository.save(user);
+
+        return new UserSocialLoginResponse(user.getId(), REGISTER, generateToken(user.getEmail()));
+    }
+
+    private JwtResponse generateToken (String email){
+        return JwtResponse.builder()
+                .accessToken(jwtProvider.generateAccessToken(email))
+                .refreshToken(jwtProvider.generateRefreshToken())
+                .build();
+    }
 
 }

--- a/src/main/java/com/leets/X/global/auth/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/leets/X/global/auth/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package com.leets.X.global.auth.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leets.X.global.common.response.ResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.leets.X.global.auth.exception.ErrorMessage.INVALID_TOKEN;
+import static com.leets.X.global.auth.exception.ErrorMessage.UNAUTHORIZED;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        Integer exceptionCode = (Integer) request.getAttribute("jwtException");
+        log.info("exception: {}", exceptionCode);
+
+        /*
+            * exceptionCode가 null이 아니라면 토큰 유효성 검사를 실패한 것이기 때문에 따로 처리
+            * exceptionCode가 null이라면 인증 정보가 없는 것이기 때문에 따로 처리
+         */
+        if (exceptionCode != null) {
+            if (exceptionCode == INVALID_TOKEN.getCode()){
+                setResponse(response, INVALID_TOKEN.getCode(), INVALID_TOKEN.getMessage());
+            }
+        } else {
+            setResponse(response, UNAUTHORIZED.getCode(), UNAUTHORIZED.getMessage());
+        }
+    }
+
+    // 발생한 예외에 맞게 status를 설정하고 message를 반환
+    private void setResponse(HttpServletResponse response, int code, String message) throws IOException {
+        response.setStatus(code);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = new ObjectMapper().writeValueAsString(ResponseDto.errorResponse(code, message));
+        response.getWriter().write(json);
+    }
+
+}
+

--- a/src/main/java/com/leets/X/global/auth/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/leets/X/global/auth/authentication/CustomAuthenticationEntryPoint.java
@@ -24,7 +24,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         Integer exceptionCode = (Integer) request.getAttribute("jwtException");
-        log.info("exception: {}", exceptionCode);
 
         /*
             * exceptionCode가 null이 아니라면 토큰 유효성 검사를 실패한 것이기 때문에 따로 처리

--- a/src/main/java/com/leets/X/global/auth/exception/ErrorMessage.java
+++ b/src/main/java/com/leets/X/global/auth/exception/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.leets.X.global.auth.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    INVALID_TOKEN(401,"유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(401, "만료된 토큰입니다."),
+    UNAUTHORIZED(401,"인증정보가 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}
+

--- a/src/main/java/com/leets/X/global/auth/google/AuthService.java
+++ b/src/main/java/com/leets/X/global/auth/google/AuthService.java
@@ -3,7 +3,6 @@ package com.leets.X.global.auth.google;
 import com.leets.X.global.auth.google.dto.GoogleTokenResponse;
 import com.leets.X.global.auth.google.dto.GoogleUserInfoResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -15,11 +14,9 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final RestClient restClient = RestClient.builder().build();
     @Value("${google.client-id}")
     private String clientId;
     @Value("${google.client-secret}")
@@ -33,11 +30,12 @@ public class AuthService {
     @Value("${google.user-info-uri}")
     private String userInfoUri;
 
+    private final RestClient restClient = RestClient.create();
 
-    public GoogleTokenResponse getGoogleAccessToken(String code) {
-
+    public GoogleTokenResponse getGoogleAccessToken(String authCode) {
         // 디코딩된 상태로 보내야 요청이 정상적으로 감
-        String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        String decode = URLDecoder.decode(authCode, StandardCharsets.UTF_8);
+
         // 요청 body를 application/x-www-form-urlencoded에 맞게 보내기 위해 MultiValueMap 사용
         MultiValueMap<String, String> bodyParams = new LinkedMultiValueMap<>();
         bodyParams.add("code", decode);

--- a/src/main/java/com/leets/X/global/auth/google/AuthService.java
+++ b/src/main/java/com/leets/X/global/auth/google/AuthService.java
@@ -1,0 +1,54 @@
+package com.leets.X.global.auth.google;
+
+import com.leets.X.global.auth.google.dto.GoogleTokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RestClient restClient = RestClient.builder().build();
+    @Value("${google.client-id}")
+    private String clientId;
+    @Value("${google.client-secret}")
+    private String clientSecret;
+    @Value("${google.redirect-uri}")
+    private String redirectUri;
+    @Value("${google.grant-type}")
+    private String grantType;
+    @Value("${google.token-uri}")
+    private String tokenUri;
+
+
+    public GoogleTokenResponse getGoogleAccessToken(String code) {
+
+        // 디코딩된 상태로 보내야 요청이 정상적으로 감
+        String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        // 요청 body를 application/x-www-form-urlencoded에 맞게 보내기 위해 MultiValueMap 사용
+        MultiValueMap<String, String> bodyParams = new LinkedMultiValueMap<>();
+        bodyParams.add("code", decode);
+        bodyParams.add("client_id", clientId);
+        bodyParams.add("client_secret", clientSecret);
+        bodyParams.add("redirect_uri", redirectUri);
+        bodyParams.add("grant_type", grantType);
+
+        return restClient.post()
+                .uri(tokenUri)
+                .body(bodyParams)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .retrieve()
+                .body(GoogleTokenResponse.class);
+    }
+
+}

--- a/src/main/java/com/leets/X/global/auth/google/AuthService.java
+++ b/src/main/java/com/leets/X/global/auth/google/AuthService.java
@@ -1,6 +1,7 @@
 package com.leets.X.global.auth.google;
 
 import com.leets.X.global.auth.google.dto.GoogleTokenResponse;
+import com.leets.X.global.auth.google.dto.GoogleUserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,8 @@ public class AuthService {
     private String grantType;
     @Value("${google.token-uri}")
     private String tokenUri;
+    @Value("${google.user-info-uri}")
+    private String userInfoUri;
 
 
     public GoogleTokenResponse getGoogleAccessToken(String code) {
@@ -49,6 +52,14 @@ public class AuthService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
                 .body(GoogleTokenResponse.class);
+    }
+
+    public GoogleUserInfoResponse getGoogleUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(userInfoUri)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(GoogleUserInfoResponse.class);
     }
 
 }

--- a/src/main/java/com/leets/X/global/auth/google/dto/GoogleTokenResponse.java
+++ b/src/main/java/com/leets/X/global/auth/google/dto/GoogleTokenResponse.java
@@ -1,0 +1,10 @@
+package com.leets.X.global.auth.google.dto;
+
+public record GoogleTokenResponse(
+        String access_token,
+        String expires_in,
+        String scope,
+        String token_type,
+        String id_token
+) {
+}

--- a/src/main/java/com/leets/X/global/auth/google/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/leets/X/global/auth/google/dto/GoogleUserInfoResponse.java
@@ -1,0 +1,7 @@
+package com.leets.X.global.auth.google.dto;
+
+public record GoogleUserInfoResponse(
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
@@ -1,0 +1,54 @@
+package com.leets.X.global.auth.jwt;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.leets.X.global.auth.exception.ErrorMessage.INVALID_TOKEN;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("jwtfilter 실행");
+        String token = getToken(request);
+        log.info("jwtfilter token: {}", token);
+
+        try {
+            if (token != null) {
+                jwtProvider.validateToken(token, request);
+
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (JwtException e) {
+            log.info("error token: {}", e.getMessage());
+            request.setAttribute("jwtException", INVALID_TOKEN.getCode());
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // request의 헤더에 Authorization에서 토큰을 추출하고 Bearer 뒷 부분 JWT 토큰만 분리하여 반환
+    private String getToken(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            // "Bearer "를 뺀 부분만 반환
+            return token.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
@@ -24,9 +24,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("jwtfilter 실행");
         String token = getToken(request);
-        log.info("jwtfilter token: {}", token);
 
         try {
             if (token != null) {
@@ -38,7 +36,6 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (JwtException e) {
             log.info("error token: {}", e.getMessage());
             request.setAttribute("jwtException", INVALID_TOKEN.getCode());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtFilter.java
@@ -30,7 +30,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         try {
             if (token != null) {
-                jwtProvider.validateToken(token, request);
+                jwtProvider.validateToken(token);
 
                 Authentication authentication = jwtProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -38,6 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (JwtException e) {
             log.info("error token: {}", e.getMessage());
             request.setAttribute("jwtException", INVALID_TOKEN.getCode());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -2,7 +2,6 @@ package com.leets.X.global.auth.jwt;
 
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -58,7 +57,7 @@ public class JwtProvider {
                 .getBody();
     }
 
-    public void validateToken(String token, HttpServletRequest request) {
+    public void validateToken(String token) {
         try {
             parseToken(token);
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -87,8 +87,8 @@ public class JwtProvider {
 
     public Authentication getAuthentication(String token) {
         Claims claims = parseToken(token);
-        String username = claims.getSubject();
+        String email = claims.getSubject();
 
-        return new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
     }
 }

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -44,9 +44,9 @@ public class JwtProvider {
     }
 
     // 이렇게 만들거나 UUID로 만들어서 레디스에 저장하기
-    public String generateRefreshToken(String email) {
-        String refreshToken = UUID.randomUUID().toString();
-        return refreshToken;
+    public String generateRefreshToken() {
+        return UUID.randomUUID().toString();
+
     }
 
     public Claims parseToken(String token) {

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -1,0 +1,94 @@
+package com.leets.X.global.auth.jwt;
+
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class JwtProvider {
+
+    @Value("${x.jwt.key}")
+    private String jwtKey;
+    private Key key;
+    @Value("${x.jwt.access.expiration}")
+    private int accessTokenExpirationTime;
+    @Value("${x.jwt.refresh.expiration}")
+    private int refreshTokenExpirationTime;
+
+    @PostConstruct
+    public void init() {
+        // jwtKey가 주입된 후에 SecretKeySpec 생성
+        this.key = new SecretKeySpec(jwtKey.getBytes(), SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    public String generateAccessToken(String email) {
+        final Date now = new Date();
+        final Date expiration = new Date(now.getTime() + accessTokenExpirationTime);
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+
+    // 이렇게 만들거나 UUID로 만들어서 레디스에 저장하기
+    public String generateRefreshToken(String email) {
+        String refreshToken = UUID.randomUUID().toString();
+        return refreshToken;
+    }
+
+    public Claims parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public void validateToken(String token, HttpServletRequest request) {
+        try {
+            parseToken(token);
+        } catch (ExpiredJwtException e) {
+            log.warn("JwtProvider: Expired token");
+            throw e;
+        } catch (UnsupportedJwtException e) {
+            log.warn("JwtProvider: Unsupported token");
+            throw e;
+        } catch (MalformedJwtException e) {
+            log.warn("JwtProvider: Malformed token");
+            throw e;
+        } catch (SignatureException e) {
+            log.warn("JwtProvider: Signature exception");
+            throw e;
+        } catch (IllegalArgumentException e) {
+            log.warn("JwtProvider: IllegalArgumentException");
+            throw e;
+        }
+    }
+
+    public JwtResponse reGenerateToken(String refreshToken, String email) {
+
+        return null;
+    }
+
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseToken(token);
+        String username = claims.getSubject();
+
+        return new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
+    }
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.leets.X.global.auth.jwt;
 
+import com.leets.X.global.auth.jwt.dto.JwtResponse;
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtResponse.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtResponse.java
@@ -1,0 +1,7 @@
+package com.leets.X.global.auth.jwt;
+
+public record JwtResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtResponse.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtResponse.java
@@ -1,5 +1,8 @@
 package com.leets.X.global.auth.jwt;
 
+import lombok.Builder;
+
+@Builder
 public record JwtResponse(
         String accessToken,
         String refreshToken

--- a/src/main/java/com/leets/X/global/auth/jwt/controller/JwtController.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/controller/JwtController.java
@@ -1,0 +1,4 @@
+package com.leets.X.global.auth.jwt.controller;
+
+public class JwtController {
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/controller/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.leets.X.global.auth.jwt.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    REISSUE_TOKEN(200, "토큰 재발급에 성공 했습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/leets/X/global/auth/jwt/dto/JwtResponse.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/dto/JwtResponse.java
@@ -1,4 +1,4 @@
-package com.leets.X.global.auth.jwt;
+package com.leets.X.global.auth.jwt.dto;
 
 import lombok.Builder;
 

--- a/src/main/java/com/leets/X/global/common/exception/BaseException.java
+++ b/src/main/java/com/leets/X/global/common/exception/BaseException.java
@@ -1,4 +1,4 @@
-package com.leets.X.global.exception;
+package com.leets.X.global.common.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/leets/X/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/X/global/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.leets.X.global.exception;
+package com.leets.X.global.common.exception;
 
 import com.leets.X.global.common.response.ResponseDto;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/leets/X/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/X/global/common/exception/GlobalExceptionHandler.java
@@ -3,10 +3,12 @@ package com.leets.X.global.common.exception;
 import com.leets.X.global.common.response.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
 @RestControllerAdvice
@@ -63,6 +65,25 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ResponseDto<Void>> handle(IllegalArgumentException e) {
         int statusCode = 400;
+
+        log.warn(e.getMessage(), e);
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());
+
+        ResponseDto<Void> response = ResponseDto.errorResponse(statusCode, e.getMessage());
+
+        return ResponseEntity
+                .status(statusCode) // 실제 HTTP 상태 코드 설정
+                .body(response);
+    }
+
+    // 소셜 로그인 중 발생할 수 있는 예외. 구글 서버로 API 요청 후 응답이 400일 경우
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ResponseDto<Void>> handle(HttpClientErrorException e) {
+        int statusCode = 400;
+
+        if(e instanceof ErrorResponse){
+            statusCode = ((ErrorResponse) e).getStatusCode().value();
+        }
 
         log.warn(e.getMessage(), e);
         log.warn(LOG_FORMAT, e.getClass().getSimpleName(), statusCode, e.getMessage());

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -1,14 +1,20 @@
 package com.leets.X.global.config;
 
+import com.leets.X.global.auth.authentication.CustomAuthenticationEntryPoint;
+import com.leets.X.global.auth.jwt.JwtFilter;
+import com.leets.X.global.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -16,6 +22,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -38,10 +47,26 @@ public class SecurityConfig {
                         authorize ->
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
+                                        .requestMatchers("/api/v1/login").permitAll()
+                                        .requestMatchers("/api/v1/users/jwt").permitAll()
                                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exceptioHandling ->
+                        exceptioHandling
+                                .authenticationEntryPoint(customAuthenticationEntryPoint))
 
                 .build();
+    }
+
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(jwtProvider);  // JwtFilter를 Bean으로 등록하고 JwtProvider를 주입
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
 

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedOriginPattern("http://localhost:3000");
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader("Authorization");

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -47,8 +47,7 @@ public class SecurityConfig {
                         authorize ->
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
-                                        .requestMatchers("/api/v1/login").permitAll()
-                                        .requestMatchers("/api/v1/users/jwt").permitAll()
+                                        .requestMatchers("/api/v1/users/login").permitAll()
                                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -15,6 +15,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -72,18 +77,18 @@ public class SecurityConfig {
     /*
     CORS 관련 설정
      */
-//    @Bean
-//    public CorsConfigurationSource corsConfigurationSource() {
-//        CorsConfiguration configuration = new CorsConfiguration();
-//
-//        configuration.setAllowedOrigins(Arrays.asList());
-//        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
-//        configuration.setAllowedHeaders(Arrays.asList("*"));
-//        configuration.setExposedHeaders(Arrays.asList("Authorization, Authorization_refresh"));
-//        configuration.setAllowCredentials(true);
-//
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        source.registerCorsConfiguration("/**", configuration);
-//        return source;
-//    }
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization, Authorization_refresh"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -19,8 +19,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
@@ -81,10 +79,11 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setExposedHeaders(Arrays.asList("Authorization, Authorization_refresh"));
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.addExposedHeader("Authorization");
+        configuration.addExposedHeader("Authorization_refresh");
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/leets/X/global/config/SwaggerConfig.java
+++ b/src/main/java/com/leets/X/global/config/SwaggerConfig.java
@@ -28,7 +28,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
-                .components(new Components().addSecuritySchemes("jwt token", securityScheme))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .security(List.of(securityRequirement));
     }
 
@@ -38,6 +38,6 @@ public class SwaggerConfig {
     }
 
     private SecurityRequirement getSecurityRequireMent() {
-        return new SecurityRequirement().addList("bearer");
+        return new SecurityRequirement().addList("bearerAuth");
     }
 }

--- a/src/main/java/com/leets/X/global/config/SwaggerConfig.java
+++ b/src/main/java/com/leets/X/global/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = getSecurityRequireMent();
 
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("jwt token", securityScheme))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .security(List.of(securityRequirement));
     }
 
@@ -36,6 +36,6 @@ public class SwaggerConfig {
     }
 
     private SecurityRequirement getSecurityRequireMent() {
-        return new SecurityRequirement().addList("bearer");
+        return new SecurityRequirement().addList("bearerAuth");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,12 @@ springdoc:
   swagger-ui:
     operations-sorter: method
     tags-sorter: alpha
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}
+  grant-type: authorization_code
+  authorization-uri: https://accounts.google.com/o/oauth2/auth
+  token-uri: https://oauth2.googleapis.com/token
+  user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 스프링 시큐리티 필터 단에서 발생하는 예외 처리를 위한 CustomEntryPoint 구현
- 적절한 인증/인가를 위한 JWT provider와 JWT filter 구현
- 구글 소셜 로그인을 위한 의존성 추가 및 구현

## 2. 어떤 위험이나 장애를 발견했나요?
- 연관된 파트들을 작업하다 보니 PR이 많이 커졌습니다..
- 빠르게 올려둘 테니 천천히 읽어보시고 리뷰 부탁드리겠습니다.

## 3. 관련 스크린샷을 첨부해주세요.
- 인증 정보(jwt token) 없이 요청을 보낼시
<img width="542" alt="image" src="https://github.com/user-attachments/assets/267c507f-006e-4e0a-a5c2-94245398f9df">

- 최초로 소셜 로그인 진행시
![image](https://github.com/user-attachments/assets/3e08af14-9175-4e6d-96da-a2df610e430a)

- 회원가입 이후 소셜 로그인 진행시
![image](https://github.com/user-attachments/assets/7f96c95b-59a0-499f-889c-ed2925729dc2)

## 4. 완료 사항
### 스프링 시큐리티 관련
인증의 경우 스프링 시큐리티 필터체인을 모두 돌아도 인증 정보가 없다면 AuthenticationException을 발생시킵니다. 해당 예외는 필터단에서 발생하는 예외이기 때문에 RestControllerAdvice를 적용한 global exception handler에서 잡지 못합니다. 따라서 해당 예외를 처리하는 AuthenticationEntryPoint를 구현한 커스텀 객체를 만들어 처리했습니다

### JWT 관련
그리고 JWTfilter는 사용자의 요청이 들어온 경우 jwt 엑세스 토큰의 유효성 검사를 진행하도록 구현했습니다.
JWT refresh의 경우 요구사항에 맞게 구현할 계획이고, 구현하게 된다면 별도의 API로 리프레시 하는 방식으로 구현할 계획입니다.
따라서 refresh  토큰은 발급은 해주고 있지만, 관련된 아무런 로직도 구현하지 않은 상태입니다

jwt provider는 jwt 토큰 발급, 유효성 검사, 인증객체 생성에 사용되는 서비스 입니다. 토큰 유효성 검사를 통과한 후에 해당 토큰의 정보로 Authentication을 저장할 수 있습니다

### 소셜 로그인 관련
소셜 로그인은 X와 동일하게 구글로 진행했습니다.
플로우: 프론트에서 client_id(우리가 구글 로그인을 받기 위해 등록한 정보)를 토대로 사용자에게 구글 로그인을 받음 -> auth code를 반환 -> 프론트는 해당 auth code를 서버로 보내 로그인 요청 -> 서버는 해당 코드를 받아 구글 유저 조회 서버로 요청을 보냄 -> 유저 조회 성공 -> DB에 없는 유저라면 저장 / 있는 유저라면 로그인 진행 -> jwt accessToken과 refreshToken을 발급

client_id, client_secret, redirect_uri는 외부에 노출되면 안되기 때문에 환경변수 처리하였습니다.

## 5. 추가 사항
- 자세한 설명은 코드 별로 코멘트 달아두겠습니다.
- 궁금한 점 있으면 언제든 질문 주세요!
### 참고자료
https://velog.io/@gmlstjq123/구글-소셜로그인-구현
https://velog.io/@bdd14club/백엔드-2.-구글-소셜-로그인-구현하기