### PR TITLE
[feat] #13 최초 로그인 시 초기 프로필 입력 API 구현

### DIFF
--- a/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
 
     USER_SAVE_SUCCESS(201,"회원가입에 성공했습니다."),
-    LOGIN_SUCCESS(200,"로그인에 성공했습니다.");
+    LOGIN_SUCCESS(200,"로그인에 성공했습니다."),
+    INIT_PROFILE_SUCCESS(200, "프로필 초기설정에 성공했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -1,21 +1,20 @@
 package com.leets.X.domain.user.controller;
 
-import com.leets.X.domain.user.service.LoginStatus;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
+import com.leets.X.domain.user.service.LoginStatus;
 import com.leets.X.domain.user.service.UserService;
 import com.leets.X.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-import static com.leets.X.domain.user.controller.ResponseMessage.LOGIN_SUCCESS;
-import static com.leets.X.domain.user.controller.ResponseMessage.USER_SAVE_SUCCESS;
+import static com.leets.X.domain.user.controller.ResponseMessage.*;
 
 // 스웨거에서 controller 단위 설명 추가
 @Tag(name = "USER")
@@ -34,6 +33,18 @@ public class UserController {
             return ResponseDto.response(LOGIN_SUCCESS.getCode(), LOGIN_SUCCESS.getMessage(), response);
         }
         return ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage(), response);
+    }
+
+    /*
+        * JWT 인증시 Authentication 객체를 만들 때 user의 email만 넣어서 만들었기 떄문에 @AuthenticationPrincipal로 인증 정보를 가져오면 email이 반환됨
+        * 우리의 경우 소셜 로그인만 진행하기 때문에 이메일 중복이 없어 해당 방식도 문제 없지만, 토큰의 subject로 user_id와 email을 넣는게 나을 것 같음
+        * 또한 인증된 사용자 정보를 객체, email로 가져오는 것보다 id로 가져오는 것이 인덱싱 방면에서 성능이 더 좋을 듯
+     */
+    @PatchMapping("/init")
+    @Operation(summary = "최초 로그인시 정보 입력")
+    public ResponseDto<String> initUserProfile(@RequestBody @Valid UserInitializeRequest request, @AuthenticationPrincipal @Parameter(hidden = true) String email) {// 스웨거에서 해당 정보 입력을 받지 않기 위해 hidden으로 설정
+        userService.initProfile(request, email);
+        return ResponseDto.response(INIT_PROFILE_SUCCESS.getCode(), INIT_PROFILE_SUCCESS.getMessage());
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -1,11 +1,12 @@
 package com.leets.X.domain.user.domain;
 
 import com.leets.X.domain.user.domain.enums.Gender;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 // mysql에서 user 테이블이 존재 하기 때문에 다른 이름으로 지정
@@ -33,7 +34,7 @@ public class User extends BaseTimeEntity {
 
     private String phoneNum;
 
-    private LocalDateTime birth;
+    private LocalDate birth;
 
     private String location;
 
@@ -44,5 +45,10 @@ public class User extends BaseTimeEntity {
     private String introduce;
 
 //    private Image image;
+
+    public void initProfile(UserInitializeRequest dto){
+        this.birth = dto.birth();
+        this.customId = dto.customId();
+    }
 
 }

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserInitializeRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserInitializeRequest.java
@@ -1,0 +1,13 @@
+package com.leets.X.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record UserInitializeRequest(
+        // 이 둘은 필수 입력이기 떄문에 NotBlank 제약
+        @NotNull LocalDate birth, // 날짜의 경우 @NotNull이 적용 x
+        @NotBlank String customId
+) {
+}

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.leets.X.domain.user.service;
 
 import com.leets.X.domain.user.domain.User;
+import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
 import com.leets.X.domain.user.exception.UserNotFoundException;
 import com.leets.X.domain.user.repository.UserRepository;
@@ -26,6 +27,9 @@ public class UserService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
+    /*
+        * 소셜 로그인
+     */
     @Transactional
     public UserSocialLoginResponse authenticate(String authCode) {
         GoogleTokenResponse token = authService.getGoogleAccessToken(authCode);
@@ -39,9 +43,18 @@ public class UserService {
         return registerUser(userInfo);
     }
 
+    /*
+        * 회원가입 시 초기 정보 입력
+     */
+    @Transactional
+    public void initProfile(UserInitializeRequest dto, String email){
+        User user = find(email);
+
+        user.initProfile(dto);
+    }
+
     private UserSocialLoginResponse loginUser(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(UserNotFoundException::new);
+        User user = find(email);
 
         return new UserSocialLoginResponse(user.getId(), LOGIN, generateToken(email));
     }
@@ -62,6 +75,15 @@ public class UserService {
                 .accessToken(jwtProvider.generateAccessToken(email))
                 .refreshToken(jwtProvider.generateRefreshToken())
                 .build();
+    }
+
+    /*
+        * userRepository에서 사용자를 검색하는 메서드
+        * 공통으로 사용되는 부분이 많기 때문에 별도로 분리
+     */
+    private User find(String email){
+        return userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/leets/X/global/auth/jwt/JwtProvider.java
@@ -87,8 +87,8 @@ public class JwtProvider {
 
     public Authentication getAuthentication(String token) {
         Claims claims = parseToken(token);
-        String username = claims.getSubject();
+        String email = claims.getSubject();
 
-        return new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 소셜 로그인을 최초로 할시 생년월일과 사용자ID를 입력받기 때문에 해당 API를 구현하였습니다

## 2. 어떤 위험이나 장애를 발견했나요?
X

## 3. 관련 스크린샷을 첨부해주세요.
X

## 4. 완료 사항
- 소셜 로그인시 user를 미리 DB에 저장한 후, 해당 유저를 업데이트해 생년월일과 커스텀 ID를 업데이트 했습니다
- 업데이트 로직이기 때문에 PATCH mapping을 사용했고, @AuthenticationPrinciple로 email을 가져와 인증된 유저 조회를 했습니다
- 위 어노테이션은 현재 요청을 보낸 사람의 Authentication 객체에서 정보를 가져오는 어노테이션으로, 프론트 측에서 JWT 토큰만 보내주면 서버 측에서 해당 정보로 현재 유저 정보를 가져올 수 있는 스프링 자체 어노테이션 입니다
- 자세한 사항은 https://velog.io/@jyleedev/AuthenticationPrincipal-로그인-정보-받아오기 참고해주세요
- 저희 로직은 자체 로그인이 없기 때문에 별도의 UserDetailsService를 커스텀하지 않아 다른 부분이 있을 수 있으나, UserNamePasswordToken을 만들어 인증 객체를 만들 때 email을 넣어 만들기 때문에 email이 반환된다고 이해해주시면 될 것 같습니다

## 5. 추가 사항
지피티의 힘을 빌리자면
	•	UserDetailsService를 이용한 방식은 사용자 정보를 UserDetails로 상세하게 관리하고, 권한을 포함한 풍부한 인증 처리가 필요할 때 적합합니다.
	•	구현하지 않은 방식은 JWT에서 간단한 정보를 추출해 인증을 처리하며, 권한 검증이나 추가적인 사용자 정보 관리가 필요하지 않은 경우 적합합니다.

상황에 따라 두 방식 중 적합한 방식을 선택하면 됩니다. saveAuthentication은 권한 검증과 사용자 정보 관리가 중요한 경우에 적합하고, getAuthentication은 간단한 인증만 필요할 때 성능적으로 더 효율적입니다.