### PR TITLE
[feat] #17 유저 프로필 수정 조회

### DIFF
--- a/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/user/controller/ResponseMessage.java
@@ -10,7 +10,9 @@ public enum ResponseMessage {
 
     USER_SAVE_SUCCESS(201,"회원가입에 성공했습니다."),
     LOGIN_SUCCESS(200,"로그인에 성공했습니다."),
-    INIT_PROFILE_SUCCESS(200, "프로필 초기설정에 성공했습니다.");
+    INIT_PROFILE_SUCCESS(200, "프로필 초기설정에 성공했습니다."),
+    PROFILE_UPDATE_SUCCESS(200, "프로필 수정에 성공했습니다."),
+    GET_PROFILE_SUCCESS(200, "유저 기본 프로필 조회에 성공했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.leets.X.domain.user.controller;
 
 import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
+import com.leets.X.domain.user.dto.request.UserUpdateRequest;
+import com.leets.X.domain.user.dto.response.UserProfileResponse;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
 import com.leets.X.domain.user.service.LoginStatus;
 import com.leets.X.domain.user.service.UserService;
@@ -46,5 +48,20 @@ public class UserController {
         userService.initProfile(request, email);
         return ResponseDto.response(INIT_PROFILE_SUCCESS.getCode(), INIT_PROFILE_SUCCESS.getMessage());
     }
+
+    @GetMapping("/profile/{userId}")
+    @Operation(summary = "유저 기본 프로필 조회")
+    public ResponseDto<UserProfileResponse> getUserProfile(@PathVariable Long userId, @AuthenticationPrincipal @Parameter(hidden = true) String email) {
+        return ResponseDto.response(GET_PROFILE_SUCCESS.getCode(), GET_PROFILE_SUCCESS.getMessage(), userService.getProfile(userId, email));
+    }
+
+    @PatchMapping("/profile")
+    @Operation(summary = "유저 프로필 수정")
+    public ResponseDto<String> updateProfile(@RequestBody @Valid UserUpdateRequest request, @AuthenticationPrincipal @Parameter(hidden = true) String email){
+        userService.updateProfile(request, email);
+        return ResponseDto.response(PROFILE_UPDATE_SUCCESS.getCode(), PROFILE_UPDATE_SUCCESS.getMessage());
+    }
+
+
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -1,7 +1,7 @@
 package com.leets.X.domain.user.domain;
 
-import com.leets.X.domain.user.domain.enums.Gender;
 import com.leets.X.domain.user.dto.request.UserInitializeRequest;
+import com.leets.X.domain.user.dto.request.UserUpdateRequest;
 import com.leets.X.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -28,11 +28,11 @@ public class User extends BaseTimeEntity {
 
     private String name;
 
-    private Gender gender;
+//    private Gender gender;
 
     private String email;
 
-    private String phoneNum;
+//    private String phoneNum;
 
     private LocalDate birth;
 
@@ -49,6 +49,13 @@ public class User extends BaseTimeEntity {
     public void initProfile(UserInitializeRequest dto){
         this.birth = dto.birth();
         this.customId = dto.customId();
+    }
+
+    public void update(UserUpdateRequest dto){
+        this.name = dto.name();
+        this.introduce = dto.introduce();
+        this.location = dto.location();
+        this.webSite = dto.webSite();
     }
 
 }

--- a/src/main/java/com/leets/X/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/leets/X/domain/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.leets.X.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record UserUpdateRequest(
+        @NotBlank String name,
+        @NotBlank String introduce,
+        @NotBlank String location,
+        @NotBlank String webSite,
+        @NotNull LocalDate birth
+) {
+}

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,28 @@
+package com.leets.X.domain.user.dto.response;
+
+import com.leets.X.domain.user.domain.User;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserProfileResponse(
+        Long userId,
+        Boolean isMyProfile,
+        String name,
+        String customId,
+        LocalDateTime createAt,
+        Long followCount,
+        Long followerCount
+) {
+    // 정적 팩토리 메서드
+    public static UserProfileResponse from(User user, Boolean isMyProfile) {
+        return UserProfileResponse.builder()
+                .userId(user.getId())
+                .isMyProfile(isMyProfile)
+                .name(user.getName())
+                .customId(user.getCustomId())
+                .createAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.leets.X.domain.user.service;
 
 import com.leets.X.domain.user.domain.User;
 import com.leets.X.domain.user.dto.request.UserInitializeRequest;
+import com.leets.X.domain.user.dto.request.UserUpdateRequest;
+import com.leets.X.domain.user.dto.response.UserProfileResponse;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
 import com.leets.X.domain.user.exception.UserNotFoundException;
 import com.leets.X.domain.user.repository.UserRepository;
@@ -53,6 +55,27 @@ public class UserService {
         User user = find(email);
 
         user.initProfile(dto);
+    }
+
+    /*
+        * 프로필 수정
+     */
+    @Transactional
+    public void updateProfile(UserUpdateRequest dto, String email){
+        User user = find(email);
+
+        user.update(dto);
+    }
+
+    public UserProfileResponse getProfile(Long userId, String email){
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        // 내 프로필이라면 true
+        if(user.getEmail().equals(email)){
+            return UserProfileResponse.from(user, true);
+        }
+        // 아니라면 false
+        return UserProfileResponse.from(user, false);
     }
 
     private UserSocialLoginResponse loginUser(String email) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 유저 도메인 중 프로필 조회, 프로필 수정 API를 구현했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
X
<br>

## 3. 관련 스크린샷을 첨부해주세요.
X
<br>

## 4. 완료 사항
- 정적 팩토리 메서드 + 빌더 패턴을 적용해 엔티티->DTO로 변환을 간편하게 하도록 구현했습니다
- 내 프로필인지 남의 프로필인지 구분하기 위해 boolean 변수를 추가했는데 프론트와 조율 후 확정할 예정입니다
- 프로필 수정의 경우 @Setter 사용을 지양하기 때문에 엔티티 내부에서 변수를 수정하는 update 메서드를 구현하였고, 해당 메서드를 통해 엔티티를 수정하게 되면 JPA의 변경감지로 인해 DB에도 적용이 됩니다
- 또한 @Transactional 어노테이션을 사용해 해당 메서드를 트랜잭션화 시켜 무결성을 지킬 수 있습니다
- 요구사항을 확인해보니 성별, 전화번호도 필요가 없는 컬럼이라 우선 주석처리 했습니다
<br>

## 5. 추가 사항
- 현재 유저 도메인으로만 구현가능한 API는 2개 밖에 없어서 팔로우, 좋아요 도메인 구현 후 완성할 예정입니다