### PR TITLE
[feat] #21 팔로우 도메인 개발

### DIFF
--- a/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
@@ -3,6 +3,8 @@ package com.leets.X.domain.follow.controller;
 import com.leets.X.domain.follow.dto.response.FollowResponse;
 import com.leets.X.domain.follow.service.FollowService;
 import com.leets.X.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +13,7 @@ import java.util.List;
 
 import static com.leets.X.domain.follow.controller.ResponseMessage.*;
 
+@Tag(name = "FOLLOW")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/follows")
@@ -18,22 +21,26 @@ public class FollowController {
     private final FollowService followService;
 
     @PostMapping("/{userId}")
+    @Operation(summary = "팔로우 하기")
     public ResponseDto<String> follow(@PathVariable Long userId, @AuthenticationPrincipal String email){
         followService.follow(userId, email);
         return ResponseDto.response(FOLLOW_SUCCESS.getCode(), FOLLOW_SUCCESS.getMessage());
     }
 
     @GetMapping("follower/{userId}")
+    @Operation(summary = "해당 유저의 팔로워 조회(해당 유저를 팔로우 하는 사용자 목록")
     public ResponseDto<List<FollowResponse>> getFollowers(@PathVariable Long userId){
         return ResponseDto.response(GET_FOLLOWER_SUCCESS.getCode(), GET_FOLLOWER_SUCCESS.getMessage(), followService.getFollowers(userId));
     }
 
     @GetMapping("following/{userId}")
+    @Operation(summary = "해당 유저의 팔로잉 조회(해당 유저가 팔로우 하는 사용자 목록")
     public ResponseDto<List<FollowResponse>> getFollowings(@PathVariable Long userId){
         return ResponseDto.response(GET_FOLLOWING_SUCCESS.getCode(), GET_FOLLOWING_SUCCESS.getMessage(), followService.getFollowings(userId));
     }
 
     @DeleteMapping("/{userId}")
+    @Operation(summary = "언팔로우 하기")
     public ResponseDto<String> unfollow(@PathVariable Long userId, @AuthenticationPrincipal String email){
         followService.unfollow(userId, email);
         return ResponseDto.response(UNFOLLOW_SUCCESS.getCode(), UNFOLLOW_SUCCESS.getMessage());

--- a/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
@@ -32,4 +32,11 @@ public class FollowController {
     public ResponseDto<List<FollowResponse>> getFollowings(@PathVariable Long userId){
         return ResponseDto.response(GET_FOLLOWING_SUCCESS.getCode(), GET_FOLLOWING_SUCCESS.getMessage(), followService.getFollowings(userId));
     }
+
+    @DeleteMapping("/{userId}")
+    public ResponseDto<String> unfollow(@PathVariable Long userId, @AuthenticationPrincipal String email){
+        followService.unfollow(userId, email);
+        return ResponseDto.response(UNFOLLOW_SUCCESS.getCode(), UNFOLLOW_SUCCESS.getMessage());
+    }
+
 }

--- a/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/leets/X/domain/follow/controller/FollowController.java
@@ -1,0 +1,35 @@
+package com.leets.X.domain.follow.controller;
+
+import com.leets.X.domain.follow.dto.response.FollowResponse;
+import com.leets.X.domain.follow.service.FollowService;
+import com.leets.X.global.common.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.leets.X.domain.follow.controller.ResponseMessage.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/follows")
+public class FollowController {
+    private final FollowService followService;
+
+    @PostMapping("/{userId}")
+    public ResponseDto<String> follow(@PathVariable Long userId, @AuthenticationPrincipal String email){
+        followService.follow(userId, email);
+        return ResponseDto.response(FOLLOW_SUCCESS.getCode(), FOLLOW_SUCCESS.getMessage());
+    }
+
+    @GetMapping("follower/{userId}")
+    public ResponseDto<List<FollowResponse>> getFollowers(@PathVariable Long userId){
+        return ResponseDto.response(GET_FOLLOWER_SUCCESS.getCode(), GET_FOLLOWER_SUCCESS.getMessage(), followService.getFollowers(userId));
+    }
+
+    @GetMapping("following/{userId}")
+    public ResponseDto<List<FollowResponse>> getFollowings(@PathVariable Long userId){
+        return ResponseDto.response(GET_FOLLOWING_SUCCESS.getCode(), GET_FOLLOWING_SUCCESS.getMessage(), followService.getFollowings(userId));
+    }
+}

--- a/src/main/java/com/leets/X/domain/follow/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/follow/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
     FOLLOW_SUCCESS(200, "팔로우에 성공했습니다."),
     GET_FOLLOWER_SUCCESS(200, "팔로워 목록 조회에 성공했습니다."),
-    GET_FOLLOWING_SUCCESS(200, "팔로잉 목록 조회에 성공했습니다.");
+    GET_FOLLOWING_SUCCESS(200, "팔로잉 목록 조회에 성공했습니다."),
+    UNFOLLOW_SUCCESS(200, "언팔로우에 성공했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/follow/controller/ResponseMessage.java
+++ b/src/main/java/com/leets/X/domain/follow/controller/ResponseMessage.java
@@ -1,0 +1,16 @@
+package com.leets.X.domain.follow.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    FOLLOW_SUCCESS(200, "팔로우에 성공했습니다."),
+    GET_FOLLOWER_SUCCESS(200, "팔로워 목록 조회에 성공했습니다."),
+    GET_FOLLOWING_SUCCESS(200, "팔로잉 목록 조회에 성공했습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/leets/X/domain/follow/domain/Follow.java
+++ b/src/main/java/com/leets/X/domain/follow/domain/Follow.java
@@ -1,2 +1,35 @@
-package com.leets.X.domain.follow.domain;public class Follow {
+package com.leets.X.domain.follow.domain;
+
+import com.leets.X.domain.user.domain.User;
+import com.leets.X.global.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Follow extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "follower_id")
+    private User follower; // 팔로우 하는 사람
+
+    @ManyToOne
+    @JoinColumn(name = "followed_id")
+    private User followed; // 팔로우 당하는 사람
+
+    public static Follow of(User follower, User followed) {
+        return Follow.builder()
+                .follower(follower)
+                .followed(followed)
+                .build();
+    }
+
 }

--- a/src/main/java/com/leets/X/domain/follow/domain/Follow.java
+++ b/src/main/java/com/leets/X/domain/follow/domain/Follow.java
@@ -19,11 +19,11 @@ public class Follow extends BaseTimeEntity {
 
     @ManyToOne
     @JoinColumn(name = "follower_id")
-    private User follower; // 팔로우 하는 사람
+    private User follower;
 
     @ManyToOne
     @JoinColumn(name = "followed_id")
-    private User followed; // 팔로우 당하는 사람
+    private User followed;
 
     public static Follow of(User follower, User followed) {
         return Follow.builder()

--- a/src/main/java/com/leets/X/domain/follow/dto/response/FollowResponse.java
+++ b/src/main/java/com/leets/X/domain/follow/dto/response/FollowResponse.java
@@ -1,0 +1,22 @@
+package com.leets.X.domain.follow.dto.response;
+
+import com.leets.X.domain.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record FollowResponse(
+        Long id,
+        String name,
+        String customId,
+        String introduce
+//        boolean followStatus
+) {
+    public static FollowResponse from(User user) {
+        return FollowResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .customId(user.getCustomId())
+                .introduce(user.getIntroduce())
+                .build();
+    }
+}

--- a/src/main/java/com/leets/X/domain/follow/exception/AlreadyFollowException.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/AlreadyFollowException.java
@@ -1,0 +1,12 @@
+package com.leets.X.domain.follow.exception;
+
+import com.leets.X.global.common.exception.BaseException;
+
+import static com.leets.X.domain.follow.exception.ErrorMessage.*;
+
+public class AlreadyFollowException extends BaseException {
+    public AlreadyFollowException() {
+        super(ALREADY_FOLLOW.getCode(), ALREADY_FOLLOW.getMessage());
+    }
+}
+

--- a/src/main/java/com/leets/X/domain/follow/exception/ErrorMessage.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.leets.X.domain.follow.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    ALREADY_FOLLOW(400,"이미 팔로우한 상태입니다."),
+    INVALID_FOLLOW(400, "자기 자신은 팔로우 할 수 없습니다.");
+
+    private final int code;
+    private final String message;
+
+}

--- a/src/main/java/com/leets/X/domain/follow/exception/ErrorMessage.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/ErrorMessage.java
@@ -9,7 +9,10 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     ALREADY_FOLLOW(400,"이미 팔로우한 상태입니다."),
-    INVALID_FOLLOW(400, "자기 자신은 팔로우 할 수 없습니다.");
+    INVALID_FOLLOW(400, "자기 자신은 팔로우 할 수 없습니다."),
+    FOLLOW_NOT_FOUND(404, "팔로우 데이터를 찾을 수 없습니다."),
+    INVALID_UNFOLLOW(400, "팔로우 하지 않은 상대는 언팔로우 할 수 없습니다.");
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/leets/X/domain/follow/exception/FollowNotFoundException.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/FollowNotFoundException.java
@@ -1,0 +1,12 @@
+package com.leets.X.domain.follow.exception;
+
+import com.leets.X.global.common.exception.BaseException;
+
+import static com.leets.X.domain.follow.exception.ErrorMessage.*;
+
+public class FollowNotFoundException extends BaseException {
+    public FollowNotFoundException() {
+        super(FOLLOW_NOT_FOUND.getCode(), FOLLOW_NOT_FOUND.getMessage());
+    }
+}
+

--- a/src/main/java/com/leets/X/domain/follow/exception/InvalidFollowException.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/InvalidFollowException.java
@@ -1,0 +1,11 @@
+package com.leets.X.domain.follow.exception;
+
+import com.leets.X.global.common.exception.BaseException;
+
+import static com.leets.X.domain.follow.exception.ErrorMessage.*;
+
+public class InvalidFollowException extends BaseException {
+    public InvalidFollowException() {
+        super(INVALID_FOLLOW.getCode(), INVALID_FOLLOW.getMessage());
+    }
+}

--- a/src/main/java/com/leets/X/domain/follow/exception/InvalidUnfollowException.java
+++ b/src/main/java/com/leets/X/domain/follow/exception/InvalidUnfollowException.java
@@ -1,0 +1,11 @@
+package com.leets.X.domain.follow.exception;
+
+import com.leets.X.global.common.exception.BaseException;
+
+import static com.leets.X.domain.follow.exception.ErrorMessage.*;
+
+public class InvalidUnfollowException extends BaseException {
+    public InvalidUnfollowException() {
+        super(INVALID_UNFOLLOW.getCode(), INVALID_UNFOLLOW.getMessage());
+    }
+}

--- a/src/main/java/com/leets/X/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/leets/X/domain/follow/repository/FollowRepository.java
@@ -4,8 +4,11 @@ import com.leets.X.domain.follow.domain.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowerIdAndFollowedId(Long followerId, Long followedId);
 
     // followerId가 포함된 객체 리스트 반환
     List<Follow> findByFollowerId(Long followerId);

--- a/src/main/java/com/leets/X/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/leets/X/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,18 @@
+package com.leets.X.domain.follow.repository;
+
+import com.leets.X.domain.follow.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    // followerId가 포함된 객체 리스트 반환
+    List<Follow> findByFollowerId(Long followerId);
+
+    // followedId가 포함된 객체 리스트 반환
+    List<Follow> findByFollowedId(Long followedId);
+
+    boolean existsByFollowerIdAndFollowedId(Long followerId, Long followedId);
+
+}

--- a/src/main/java/com/leets/X/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/X/domain/follow/service/FollowService.java
@@ -40,8 +40,7 @@ public class FollowService {
 
         return followerList.stream()
                 .map(follow -> {
-                    return FollowResponse.from(follow.getFollower());
-                })
+                    return FollowResponse.from(follow.getFollower()); })
                 .toList();
     }
 
@@ -52,8 +51,7 @@ public class FollowService {
 
         return followerList.stream()
                 .map(follow -> {
-                    return FollowResponse.from(follow.getFollowed());
-                })
+                    return FollowResponse.from(follow.getFollowed()); })
                 .toList();
     }
 
@@ -62,7 +60,7 @@ public class FollowService {
     public void unfollow(Long userId, String email){
         User follower = userService.find(email);
         User followed = userService.find(userId);
-        // 팔로우 정보가 없는지 체크
+
         Follow follow = check(follower.getId(), followed.getId());
 
         followRepository.delete(follow);
@@ -73,6 +71,7 @@ public class FollowService {
                 .orElseThrow(FollowNotFoundException::new);
     }
 
+    // 기존 팔로우 정보가 있는지, 나한테 요청을 하지 않는지 검증
     private void validate(Long followerId, Long followedId){
         if(followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)){
             throw new AlreadyFollowException();

--- a/src/main/java/com/leets/X/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/X/domain/follow/service/FollowService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -36,8 +35,8 @@ public class FollowService {
     // user를 팔로우 하는 사람 리스트. user는 팔로우 당하는 사람이므로 followeId에 있어야함
     public List<FollowResponse> getFollowers(Long userId){
         User user = userService.find(userId);
+
         List<Follow> followerList = followRepository.findByFollowedId(userId);
-        List<FollowResponse> followerResponses = new ArrayList<>();
 
         return followerList.stream()
                 .map(follow -> {
@@ -48,8 +47,8 @@ public class FollowService {
 
     public List<FollowResponse> getFollowings(Long userId){
         User user = userService.find(userId);
+
         List<Follow> followerList = followRepository.findByFollowerId(userId);
-        List<FollowResponse> followerResponses = new ArrayList<>();
 
         return followerList.stream()
                 .map(follow -> {

--- a/src/main/java/com/leets/X/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/X/domain/follow/service/FollowService.java
@@ -1,0 +1,69 @@
+package com.leets.X.domain.follow.service;
+
+import com.leets.X.domain.follow.domain.Follow;
+import com.leets.X.domain.follow.dto.response.FollowResponse;
+import com.leets.X.domain.follow.exception.AlreadyFollowException;
+import com.leets.X.domain.follow.exception.InvalidFollowException;
+import com.leets.X.domain.follow.repository.FollowRepository;
+import com.leets.X.domain.user.domain.User;
+import com.leets.X.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final UserService userService;
+
+    // email -> userId 방향. 팔로우 하는 사람이 follower
+    @Transactional
+    public void follow(Long userId, String email){
+        User follower = userService.find(email);
+        User followed = userService.find(userId);
+
+        check(follower.getId(), followed.getId());
+        // 저장
+        Follow follow = followRepository.save(Follow.of(follower, followed));
+    }
+
+    // user를 팔로우 하는 사람 리스트. user는 팔로우 당하는 사람이므로 followeId에 있어야함
+    public List<FollowResponse> getFollowers(Long userId){
+        User user = userService.find(userId);
+        List<Follow> followerList = followRepository.findByFollowedId(userId);
+        List<FollowResponse> followerResponses = new ArrayList<>();
+
+        return followerList.stream()
+                .map(follow -> {
+                    return FollowResponse.from(follow.getFollower());
+                })
+                .toList();
+    }
+
+    public List<FollowResponse> getFollowings(Long userId){
+        User user = userService.find(userId);
+        List<Follow> followerList = followRepository.findByFollowerId(userId);
+        List<FollowResponse> followerResponses = new ArrayList<>();
+
+        return followerList.stream()
+                .map(follow -> {
+                    return FollowResponse.from(follow.getFollowed());
+                })
+                .toList();
+    }
+
+    private void check(Long followerId, Long followedId){
+        if(followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)){
+            throw new AlreadyFollowException();
+        }
+
+        if(followerId.equals(followedId)){
+            throw new InvalidFollowException();
+        }
+    }
+
+}

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.leets.X.domain.user.domain;
 
+import com.leets.X.domain.follow.domain.Follow;
 import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.request.UserUpdateRequest;
 import com.leets.X.global.common.domain.BaseTimeEntity;
@@ -7,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 // mysql에서 user 테이블이 존재 하기 때문에 다른 이름으로 지정
@@ -46,6 +49,12 @@ public class User extends BaseTimeEntity {
 
 //    private Image image;
 
+    @OneToMany(mappedBy = "followed", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Follow> followerList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Follow> followingList = new ArrayList<>();
+
     public void initProfile(UserInitializeRequest dto){
         this.birth = dto.birth();
         this.customId = dto.customId();
@@ -57,5 +66,23 @@ public class User extends BaseTimeEntity {
         this.location = dto.location();
         this.webSite = dto.webSite();
     }
+
+    public void addFollower(Follow follow) {
+        this.followerList.add(follow);
+    }
+
+    public void addFollowing(Follow follow) {
+        this.followingList.add(follow);
+    }
+
+    public void removeFollower(Follow follow) {
+        this.followerList.remove(follow);
+    }
+
+    public void removeFollowing(Follow follow) {
+        this.followingList.remove(follow);
+    }
+
+
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -1,5 +1,8 @@
 package com.leets.X.domain.user.domain;
 
+import com.leets.X.domain.follow.domain.Follow;
+import com.leets.X.domain.like.domain.Like;
+import com.leets.X.domain.post.domain.Post;
 import com.leets.X.domain.user.dto.request.UserInitializeRequest;
 import com.leets.X.domain.user.dto.request.UserUpdateRequest;
 import com.leets.X.global.common.domain.BaseTimeEntity;

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -111,6 +111,11 @@ public class UserService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    public User find(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
     public boolean existUser(String email){
         return userRepository.existsByEmail(email);
     }

--- a/src/main/java/com/leets/X/domain/user/service/UserService.java
+++ b/src/main/java/com/leets/X/domain/user/service/UserService.java
@@ -77,6 +77,11 @@ public class UserService {
         // 아니라면 false
         return UserProfileResponse.from(user, false);
     }
+//
+//    @Transactional
+//    public void delete(Long userId){
+//        userRepository.deleteById(userId);
+//    }
 
     private UserSocialLoginResponse loginUser(String email) {
         User user = find(email);

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
                                         .requestMatchers("/api/v1/users/login").permitAll()
-                                        .requestMatchers("/api/v1/follows/follower/{userId}", "/api/v1/follows/following/{userId}").permitAll()
+//                                        .requestMatchers("/api/v1/follows/follower/{userId}", "/api/v1/follows/following/{userId}").permitAll()
                                         .requestMatchers("/api/v1/users/profile/{userId}").permitAll()
                                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
                                         .requestMatchers("/api/v1/users/login").permitAll()
+                                        .requestMatchers("/api/v1/follows/follower/{userId}", "/api/v1/follows/following/{userId}").permitAll()
+                                        .requestMatchers("/api/v1/users/profile/{userId}").permitAll()
                                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/leets/X/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/X/global/config/SecurityConfig.java
@@ -51,7 +51,6 @@ public class SecurityConfig {
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
                                         .requestMatchers("/api/v1/users/login").permitAll()
-//                                        .requestMatchers("/api/v1/follows/follower/{userId}", "/api/v1/follows/following/{userId}").permitAll()
                                         .requestMatchers("/api/v1/users/profile/{userId}").permitAll()
                                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 팔로우 도메인 개발했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- X
<br>

## 3. 관련 스크린샷을 첨부해주세요.
- 팔로우
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/6775efb6-a13c-46be-bbf3-dfa9cda1a4de">
- 팔로워 목록 조회 ( 형식은 팔로잉 조회도 동일)
<img width="574" alt="image" src="https://github.com/user-attachments/assets/1896ebc6-9b62-4842-8f3f-0fbb54dadc2f">

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/847a2a95-bc21-4036-9ce9-6297cdeb33b9">
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/f8542345-305f-418e-b025-574279bf0d76">

<br>

## 4. 완료 사항
- 팔로우, 팔로워 목록 조회, 팔로잉 목록 조회, 언팔로우 총 4개 API 구현했습니다
- 유저 탈퇴를 고려해 양방향 매핑을 사용하여 유저 삭제시 팔로우도 삭제될 수 있도록 구현했습니다. 하지만 이 방식이 좋은 방식인지는 고민이 필요할 것 같습니다
<br>

## 5. 추가 사항
- 팔로우의 경우 "나" -> 다른유저로 이루어지기 때문에 토큰이 필요합니다. 언팔로우도 마찬가지 입니다
- 팔로우 목록 조회, 팔로잉 목록 조회의 경우 나의 목록만 조회하는 것이 아니라 다른 사람의 목록도 조회할 수 있기 때문에 토큰은 검증용으로만 사용하고 실제 데이터를 사용하지는 않습니다
- 팔로우의 경우 User와 양방향 매핑을 맺진 않았습니다. 현재 기능에서는 오히려 혼동을 주는 방식이라서 일단은 단방향으로만 구현을 했습니다
- 테이블의 컬럼 명을 follower, following으로 하다 보니 혼동이 생겨 follower: 팔로우 하는 사람, followed: 팔로우 당하는 사람으로 구분을 하였습니다. 더 나은 네이밍이 있다면 언제나 환영입니다! 😁😁
