### PR TITLE
[feat] #26 팔로워수 반환 및 프로필 조회시 팔로우 여부 반환

### DIFF
--- a/src/main/java/com/leets/X/domain/follow/service/FollowService.java
+++ b/src/main/java/com/leets/X/domain/follow/service/FollowService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,7 @@ public class FollowService {
     private final UserService userService;
 
     @Transactional
-    public void follow(Long userId, String email){
+    public void follow(Long userId, String email) {
         User follower = userService.find(email);
         User followed = userService.find(userId);
 
@@ -32,62 +33,86 @@ public class FollowService {
         Follow follow = followRepository.save(Follow.of(follower, followed));
 
         follower.addFollowing(follow);
+        follower.updateFollowingCount(countFollowing(follower));
+
         followed.addFollower(follow);
+        followed.updateFollowerCount(countFollower(followed));
     }
 
-    public List<FollowResponse> getFollowers(Long userId){
+    public List<FollowResponse> getFollowers(Long userId) {
         User user = userService.find(userId);
 
         List<Follow> followerList = user.getFollowerList();
 
         return followerList.stream()
                 .map(follow -> {
-                    return FollowResponse.from(follow.getFollower()); })
+                    return FollowResponse.from(follow.getFollower());
+                })
                 .toList();
     }
 
-    public List<FollowResponse> getFollowings(Long userId){
+    public List<FollowResponse> getFollowings(Long userId) {
         User user = userService.find(userId);
 
         List<Follow> followingList = user.getFollowingList();
 
         return followingList.stream()
                 .map(follow -> {
-                    return FollowResponse.from(follow.getFollowed()); })
+                    return FollowResponse.from(follow.getFollowed());
+                })
                 .toList();
     }
 
     @Transactional
-    public void unfollow(Long userId, String email){
+    public void unfollow(Long userId, String email) {
         User follower = userService.find(email);
         User followed = userService.find(userId);
 
         Follow follow = check(follower.getId(), followed.getId());
 
         follower.removeFollowing(follow);
+        follower.decreaseFollowingCount();
+
         followed.removeFollower(follow);
+        followed.decreaseFollowerCount();
 
         followRepository.delete(follow);
     }
 
-    public Follow find(Long followerId, Long followedId){
+    public Follow find(Long followerId, Long followedId) {
         return followRepository.findByFollowerIdAndFollowedId(followerId, followedId)
                 .orElseThrow(FollowNotFoundException::new);
     }
 
+    private Long countFollower(User user) {
+        return user.getFollowerList().stream()
+                .map(follow -> {
+                    return FollowResponse.from(follow.getFollower());
+                })
+                .count();
+    }
+
+    private Long countFollowing(User user) {
+        return user.getFollowingList().stream()
+                .map(follow -> {
+                    return FollowResponse.from(follow.getFollowed());
+                })
+                .count();
+    }
+
     // 기존 팔로우 정보가 있는지, 나한테 요청을 하지 않는지 검증
-    private void validate(Long followerId, Long followedId){
-        if(followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)){
+    private void validate(Long followerId, Long followedId) {
+        if (followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)) {
             throw new AlreadyFollowException();
         }
-        if(followerId.equals(followedId)){
+        if (followerId.equals(followedId)) {
             throw new InvalidFollowException();
         }
     }
 
     // 팔로우 되어 있는지 확인
-    private Follow check(Long followerId, Long followedId){
-        if(!followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)){
+    private Follow check(Long followerId, Long followedId) {
+        if (!followRepository.existsByFollowerIdAndFollowedId(followerId, followedId)) {
             throw new InvalidUnfollowException();
         }
         return find(followerId, followedId);

--- a/src/main/java/com/leets/X/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/X/domain/user/controller/UserController.java
@@ -5,7 +5,7 @@ import com.leets.X.domain.user.dto.request.UserSocialLoginRequest;
 import com.leets.X.domain.user.dto.request.UserUpdateRequest;
 import com.leets.X.domain.user.dto.response.UserProfileResponse;
 import com.leets.X.domain.user.dto.response.UserSocialLoginResponse;
-import com.leets.X.domain.user.service.LoginStatus;
+import com.leets.X.domain.user.domain.enums.LoginStatus;
 import com.leets.X.domain.user.service.UserService;
 import com.leets.X.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/leets/X/domain/user/domain/User.java
+++ b/src/main/java/com/leets/X/domain/user/domain/User.java
@@ -49,6 +49,9 @@ public class User extends BaseTimeEntity {
 
     private String introduce;
 
+    private long followerCount = 0L;
+
+    private long followingCount = 0L;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();
@@ -90,6 +93,24 @@ public class User extends BaseTimeEntity {
         this.followingList.remove(follow);
     }
 
+    public void updateFollowerCount(long followerCount) {
+        this.followerCount = followerCount;
+    }
 
+    public void decreaseFollowerCount() {
+        if(this.followerCount > 0){
+            this.followerCount--;
+        }
+    }
+
+    public void updateFollowingCount(long followingCount) {
+        this.followingCount = followingCount;
+    }
+
+    public void decreaseFollowingCount() {
+        if(this.followingCount>0) {
+            this.followingCount--;
+        }
+    }
 
 }

--- a/src/main/java/com/leets/X/domain/user/domain/enums/LoginStatus.java
+++ b/src/main/java/com/leets/X/domain/user/domain/enums/LoginStatus.java
@@ -1,4 +1,4 @@
-package com.leets.X.domain.user.service;
+package com.leets.X.domain.user.domain.enums;
 
 public enum LoginStatus {
     LOGIN, REGISTER

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
@@ -13,10 +13,12 @@ public record UserProfileResponse(
         String customId,
         Long followerCount,
         Long followingCount,
-        LocalDateTime createAt
+        Boolean isFollowing,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
         ) {
     // 정적 팩토리 메서드
-    public static UserProfileResponse from(User user, Boolean isMyProfile) {
+    public static UserProfileResponse from(User user, Boolean isMyProfile, Boolean isFollowing) {
         return UserProfileResponse.builder()
                 .userId(user.getId())
                 .isMyProfile(isMyProfile)
@@ -24,7 +26,9 @@ public record UserProfileResponse(
                 .customId(user.getCustomId())
                 .followerCount(user.getFollowerCount())
                 .followingCount(user.getFollowingCount())
-                .createAt(user.getCreatedAt())
+                .isFollowing(isFollowing)
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserProfileResponse.java
@@ -11,10 +11,10 @@ public record UserProfileResponse(
         Boolean isMyProfile,
         String name,
         String customId,
-        LocalDateTime createAt,
-        Long followCount,
-        Long followerCount
-) {
+        Long followerCount,
+        Long followingCount,
+        LocalDateTime createAt
+        ) {
     // 정적 팩토리 메서드
     public static UserProfileResponse from(User user, Boolean isMyProfile) {
         return UserProfileResponse.builder()
@@ -22,6 +22,8 @@ public record UserProfileResponse(
                 .isMyProfile(isMyProfile)
                 .name(user.getName())
                 .customId(user.getCustomId())
+                .followerCount(user.getFollowerCount())
+                .followingCount(user.getFollowingCount())
                 .createAt(user.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
+++ b/src/main/java/com/leets/X/domain/user/dto/response/UserSocialLoginResponse.java
@@ -1,6 +1,6 @@
 package com.leets.X.domain.user.dto.response;
 
-import com.leets.X.domain.user.service.LoginStatus;
+import com.leets.X.domain.user.domain.enums.LoginStatus;
 import com.leets.X.global.auth.jwt.dto.JwtResponse;
 import lombok.Builder;
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 유저 프로필 조회시 팔로워수, 팔로잉 수를 반환
- 다른 유저의 프로필 조회 시 내가 해당 유저를 팔로우 했는지 여부 반환
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- UserService의 FollowService를 서로 참조하게 되면 순환참조 오류가 발생함
- 순환참조 주의
<br>

## 3. 관련 스크린샷을 첨부해주세요.
- 남의 프로필 조회 ( 팔로우 되어있는 상태)
<img width="944" alt="image" src="https://github.com/user-attachments/assets/88cf8f05-c585-445b-9747-5533313977c3">
- 내 프로필 조회 
<img width="947" alt="image" src="https://github.com/user-attachments/assets/98c04a55-e6a5-4da4-b98e-323375fbf73c">

<br>

## 4. 완료 사항
- 팔로워, 팔로잉 수를 계산하는 경우 `follow`시 팔로워, 팔로잉의 객체를 가져와서 update하고, `unfollow`시 count를 낮추는 방식을 선택했습니다
- 매 조회시 재계산을 하게되면 db를 매번 조회해와야하기 때문에 해당 방식을 선택했습니다
<br>

## 5. 추가 사항
X